### PR TITLE
New audio and video filetype support

### DIFF
--- a/upnp-mediaserver.c
+++ b/upnp-mediaserver.c
@@ -105,12 +105,18 @@ static const char soap_suffix[] =
 	"</s:Envelope>";
 static const struct filetype filetypes[] = {
 	{"", "application/octet-stream", "object.item"},
+	// audio
 	{"flac", "audio/flac", "object.item.audioItem"},
-	{"wav", "audio/wav", "object.item.audioItem"},
-	{"mkv", "video/x-matroska", "object.item.videoItem"},
-	{"mp4", "video/mp4", "object.item.videoItem"},
 	{"mp3", "audio/mpeg", "object.item.audioItem"},
+	{"ogg", "audio/ogg", "object.item.audioItem"},
+	{"opus", "audio/opus", "object.item.audioItem"},
+	{"wav", "audio/wav", "object.item.audioItem"},
+	//video
+	{"mp4", "video/mp4", "object.item.videoItem"},
+	{"mkv", "video/x-matroska", "object.item.videoItem"},
 	{"mov", "video/quicktime", "object.item.videoItem"},
+	{"webm", "video/webm", "object.item.videoItem"},
+	//image
 	{"jpg", "image/jpeg", "object.item.imageItem"},
 	{"png", "image/png", "object.item.imageItem"},
 };


### PR DESCRIPTION
Support for ogg and opus have been added in, and webm has been added in for
video support. File types separated by type as well.

I discovered your project here:
https://sqlite.org/althttpd/forumpost/8742054f6760dca8

The webserver I'm using is `althttpd`, which is written by Richard Hipp.